### PR TITLE
springtainer-common: Update auf Spring Boot 4.1.X und Java 25

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,7 @@ on:
     branches:
       # Runs only on push to the master branch
       - master
+      - spring-boot-4-migration
 
 jobs:
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,6 @@ on:
     branches:
       # Runs only on push to the master branch
       - master
-      - spring-boot-4-migration
 
 jobs:
   release:

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 <dependency>
   <groupId>com.avides.springboot.springtainer</groupId>
   <artifactId>springtainer-common</artifactId>
-  <version>2.0.0</version>
+  <version>3.0.0-RC1</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     <maven-failsafe-plugin.version>3.5.6</maven-failsafe-plugin.version>
     <maven-enforcer-plugin.version>3.6.3</maven-enforcer-plugin.version>
     <maven-release-plugin.version>3.3.1</maven-release-plugin.version>
-    <maven-scm-provider-gitexe.version>1.11.3</maven-scm-provider-gitexe.version>
+    <maven-scm-provider-gitexe.version>2.2.1</maven-scm-provider-gitexe.version>
     <exists-maven-plugin.version>0.15.2</exists-maven-plugin.version>
     <central-publishing-maven-plugin.version>0.11.0</central-publishing-maven-plugin.version>
     <!-- Common -->

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>com.avides.springboot.springtainer</groupId>
   <artifactId>springtainer-common</artifactId>
-  <version>2.0.0</version>
+  <version>3.0.0-RC1</version>
 
   <name>springtainer-common</name>
   <description>Common utils for springtainer</description>
@@ -40,7 +40,7 @@
     <!-- Build -->
     <maven.build.timestamp.format>dd.MM.yyyy HH:mm</maven.build.timestamp.format>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <java.version>21</java.version>
+    <java.version>25</java.version>
     <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
     <maven-source-plugin.version>3.4.0</maven-source-plugin.version>
     <maven-javadoc-plugin.version>3.12.0</maven-javadoc-plugin.version>
@@ -53,8 +53,8 @@
     <exists-maven-plugin.version>0.15.2</exists-maven-plugin.version>
     <central-publishing-maven-plugin.version>0.11.0</central-publishing-maven-plugin.version>
     <!-- Common -->
-    <spring-boot.version>3.5.16</spring-boot.version>
-    <spring-cloud-starter-bootstrap.version>4.3.3</spring-cloud-starter-bootstrap.version>
+    <spring-boot.version>4.1.0</spring-boot.version>
+    <spring-cloud-starter-bootstrap.version>5.0.2</spring-cloud-starter-bootstrap.version>
     <!-- lombok must be pinned explicitly for the annotation-processor path; kept in sync with the Spring Boot BOM -->
     <lombok.version>1.18.46</lombok.version>
     <!-- Other -->
@@ -243,6 +243,12 @@
         <configuration>
           <release>${java.version}</release>
           <parameters>true</parameters>
+          <!-- JDK 23+ no longer enables annotation processing for processors found on the classpath (JEP "javac
+               should not enable annotation processing by default"). Without this, Lombok silently does nothing and
+               the build fails with "cannot find symbol" on every generated getter and log field. Using proc=full
+               rather than annotationProcessorPaths keeps spring-boot-configuration-processor working too - the
+               latter replaces classpath scanning entirely and would silently drop it. -->
+          <proc>full</proc>
         </configuration>
       </plugin>
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -243,11 +243,9 @@
         <configuration>
           <release>${java.version}</release>
           <parameters>true</parameters>
-          <!-- JDK 23+ no longer enables annotation processing for processors found on the classpath (JEP "javac
-               should not enable annotation processing by default"). Without this, Lombok silently does nothing and
-               the build fails with "cannot find symbol" on every generated getter and log field. Using proc=full
-               rather than annotationProcessorPaths keeps spring-boot-configuration-processor working too - the
-               latter replaces classpath scanning entirely and would silently drop it. -->
+          <!-- Lombok and spring-boot-configuration-processor are picked up from the classpath, which requires
+               annotation processing to be enabled explicitly. annotationProcessorPaths is not an option here: it
+               replaces classpath scanning entirely and would drop the configuration processor. -->
           <proc>full</proc>
         </configuration>
       </plugin>


### PR DESCRIPTION
Hebt `springtainer-common` auf Spring Boot 4.1.0 und Java 25. Zielversion **3.0.0-RC1**.

### Merge-Reihenfolge

Keine Ketten-Abhaengigkeiten, die CI kann sofort gruen werden.

Ticket: https://avides.atlassian.net/browse/LIBRARIES-1752
Epic: https://avides.atlassian.net/browse/ITGS-470